### PR TITLE
Add validation on mount if pristine prop is false

### DIFF
--- a/packages/core/src/components/Form/Form.test.tsx
+++ b/packages/core/src/components/Form/Form.test.tsx
@@ -163,6 +163,66 @@ describe('component: Form', () => {
             // Cleanup
             (console.error as any).mockRestore();
         });
+
+        it.only.each([
+            [
+                'should validate component on registration if it is not initially pristine',
+                {
+                    pristine: false,
+                    expectedValidatorData: {
+                        context: ValidatorContext.Warning,
+                        message: 'Custom warning message',
+                    },
+                },
+            ],
+            [
+                'should not validate component on registration if component is pristine',
+                {
+                    pristine: true,
+                    expectedValidatorData: undefined,
+                },
+            ],
+            [
+                'should not validate component on registration if no pristine prop provided (undefined)',
+                {
+                    pristine: undefined,
+                    expectedValidatorData: undefined,
+                },
+            ],
+        ])('%s', (_, { pristine, expectedValidatorData }) => {
+            const componentName = 'firstName';
+            const wrapper = mount(
+                <Form>
+                    <TextField
+                        name={componentName}
+                        validatorRules={{
+                            custom: () => {
+                                return {
+                                    context: ValidatorContext.Warning,
+                                    message: 'Custom warning message',
+                                };
+                            },
+                        }}
+                        pristine={pristine}
+                        value="Tai"
+                    />
+                </Form>,
+            );
+
+            const form = wrapper.instance() as any;
+
+            // Pristine prop should determine whether it should be validated on initial load/registration
+            // We check component validatorData and instance._state as they should both contain validator data
+            expect(form.components[componentName].validatorData).toStrictEqual(
+                expectedValidatorData,
+            );
+            expect(
+                form.components[componentName].instance._state.validatorData,
+            ).toStrictEqual({
+                context: expectedValidatorData?.context,
+                message: expectedValidatorData?.message,
+            });
+        });
     });
 
     describe('form mirror registration/unregistration', () => {

--- a/packages/core/src/components/Form/Form.tsx
+++ b/packages/core/src/components/Form/Form.tsx
@@ -643,6 +643,11 @@ export class Form<FormComponents extends ValueMap = {}> extends React.Component<
                 },
             },
         });
+
+        // Force validation if component is not initially pristine to populate validationData
+        if (!componentRef.isPristine()) {
+            this.validate(componentName);
+        }
     };
 
     /**

--- a/packages/core/src/components/Form/Form.tsx
+++ b/packages/core/src/components/Form/Form.tsx
@@ -1005,7 +1005,6 @@ export class Form<FormComponents extends ValueMap = {}> extends React.Component<
         this.components = update(this.components, {
             [componentName]: componentTransform,
         });
-        // console.log(this.components.amount.pristine);
 
         const component = this.components[componentName];
         if (component && component.instance) {

--- a/services/demo/src/view/forms/RegistrationForm.tsx
+++ b/services/demo/src/view/forms/RegistrationForm.tsx
@@ -94,7 +94,7 @@ export const RegistrationForm: React.FC<RegistrationFormProps> = ({
                 <Grid item xs={12}>
                     <Typography variant="h5">Registration form</Typography>
                 </Grid>
-                <Grid item sm={4} xs={12}>
+                <Grid item sm={6} xs={12}>
                     {/* External validator example */}
                     <TextField
                         name="username"
@@ -108,7 +108,18 @@ export const RegistrationForm: React.FC<RegistrationFormProps> = ({
                         required
                     />
                 </Grid>
-                <Grid item sm={4} xs={12}>
+                <Grid item sm={6} xs={12}>
+                    {/* Custom validator rule example */}
+                    <TextField
+                        name="dob"
+                        label="Date of birth"
+                        validatorRules={{
+                            custom: validateDob,
+                        }}
+                        required
+                    />
+                </Grid>
+                <Grid item sm={6} xs={12}>
                     {/* Multi-rule and custom validator message example */}
                     <TextField
                         name="email"
@@ -125,14 +136,17 @@ export const RegistrationForm: React.FC<RegistrationFormProps> = ({
                         required
                     />
                 </Grid>
-                <Grid item sm={4} xs={12}>
-                    {/* Custom validator rule example */}
+                <Grid item sm={6} xs={12}>
+                    {/* Validator rules triggered on default value with non pristine form example */}
                     <TextField
-                        name="dob"
-                        label="Date of birth"
+                        name="mobile"
+                        label="Mobile"
+                        defaultValue="04123456789"
                         validatorRules={{
-                            custom: validateDob,
+                            // Invalid mobile number if > 10 digits
+                            maxLength: 10,
                         }}
+                        pristine={false}
                         required
                     />
                 </Grid>


### PR DESCRIPTION
Good morning again Peter,

There were actually 2 problems with the pristine validation:
1. Pristine prop wasn't coming through properly (Fixed in first PR)
2. Validation does not occur on initial load for `validationRule` so `validationData` is always undefined for `onComponentMount` (This PR)

With (1.) fixed, it now correctly passes through the `validationData` prop. However, in cases where we don't define the `validationData` prop and instead use `validationRule` prop, the `validationData` will be undefined on mount. This PR forces validation if it isn't pristine on mount (`registerComponent()`) to allow it to correctly get `validationData` from `validationRule`.

With this change, initial validation is working correctly now for both `validationData` and `validationRule`, but **just wanted to double-check if this was the ideal solution before writing unit tests**

Lmk if you need any further clarifications